### PR TITLE
fix git.apache.org not reachable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,3 +47,5 @@ replace k8s.io/client-go => k8s.io/client-go v11.0.1-0.20190606204521-b8faab9c51
 replace k8s.io/kubernetes => k8s.io/kubernetes v1.14.3
 
 replace go.opencensus.io => go.opencensus.io v0.19.3
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/apache/thrift v0.12.0 h1:pODnxUFNcjP9UTLZGTdeh+j16A8lJbRvD3rOtrk/7bs=
+github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=


### PR DESCRIPTION
git.apache.org is not reliable. Moving to upstream code.

```
go: git.apache.org/thrift.git@v0.12.0: unknown revision v0.12.0                                                                                               
go: error loading module requirements                                                                                                                         
make: *** [Makefile:40: bin/virtual-kubelet] Error 1                                                                                                          
[mjudeiki@localhost cri]$ make build                                                                                                                          
CGO_ENABLED=0 go build -ldflags '-ex
```
Similar issue: https://github.com/scottleedavis/mattermost-plugin-remind/issues/165

